### PR TITLE
Fix replay sending chat messages again

### DIFF
--- a/src/ArenaReplay.cpp
+++ b/src/ArenaReplay.cpp
@@ -75,9 +75,7 @@ std::vector<Opcodes> watchList =
         SMSG_DISMOUNT,
         CMSG_MOUNTSPECIAL_ANIM,
         SMSG_MOUNTSPECIAL_ANIM,
-        SMSG_MIRRORIMAGE_DATA,
-        CMSG_MESSAGECHAT,
-        SMSG_MESSAGECHAT
+        SMSG_MIRRORIMAGE_DATA
 };
 
 /*


### PR DESCRIPTION
Tested in-game using whisper, say, yell, and guild chat.
Now, the previous chats no longer reappear in the replay. Real-time chat still appears while watching a replay.
This will not work on already stored replay games.

Closes https://github.com/azerothcore/mod-arena-replay/issues/18