### PR TITLE
fix(Core): Update CanPacketSend signature to const WorldPacket&

### DIFF
--- a/src/ArenaReplay.cpp
+++ b/src/ArenaReplay.cpp
@@ -104,7 +104,7 @@ public:
         SERVERHOOK_CAN_PACKET_SEND
     }) {}
 
-    bool CanPacketSend(WorldSession* session, WorldPacket& packet) override
+    bool CanPacketSend(WorldSession* session, WorldPacket const& packet) override
     {
         if (session == nullptr || session->GetPlayer() == nullptr)
             return true;


### PR DESCRIPTION
Adapts to azerothcore/azerothcore-wotlk#25063 which changes `CanPacketSend` to take `WorldPacket const&` instead of `WorldPacket&`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)